### PR TITLE
Change I to ID

### DIFF
--- a/test/Delta.cpp
+++ b/test/Delta.cpp
@@ -92,15 +92,15 @@ TEST(Delta, Identity) {
   static constexpr ttl::Index<'j'> j;
   static constexpr ttl::Index<'k'> k;
   static constexpr ttl::Index<'l'> l;
-  auto I = Identity<3,int>();
-  std::cout << "I\n" << I(i,j,k,l) << "\n";
+  auto ID = Identity<3,int>();
+  std::cout << "I\n" << ID(i,j,k,l) << "\n";
 
   ttl::Tensor<2,3,int> A = {1, 3, 5,
                             7, 9, 11,
                             13, 15, 17}, B{};
 
   std::cout << "A\n" << A(i,j) << "\n";
-  B(i,j) = I(i,j,k,l) * A(k,l);
+  B(i,j) = ID(i,j,k,l) * A(k,l);
   std::cout << "B\n" << B(i,j) << "\n";
 
   for (int i = 0; i < 3; ++i) {

--- a/test/Identity.cpp
+++ b/test/Identity.cpp
@@ -43,19 +43,19 @@ TEST(Identity, Vector) {
 }
 
 TEST(Identity, Matrix) {
-  Tensor<4,3,int> I = identity(i,j,k,l), J;
+  Tensor<4,3,int> ID = identity(i,j,k,l), J;
   J(i,j,k,l) = identity(i,j,k,l);
 
-  std::cout << "I\n" << I(i,j,k,l) << "\n";
+  std::cout << "I\n" << ID(i,j,k,l) << "\n";
 
 
   Tensor<2,3,int> A = {1,2,3,4,5,6,7,8,9},
-                  B = I(i,j,k,l)*A(k,l),
+                  B = ID(i,j,k,l)*A(k,l),
                   C = J(i,j,k,l)*A(k,l),
                   D = identity(i,j,k,l)*A(k,l),
                       E, F, G;
 
-  E(i,j) = I(i,j,k,l)*A(k,l);
+  E(i,j) = ID(i,j,k,l)*A(k,l);
   F(i,j) = J(i,j,k,l)*A(k,l);
   G(i,j) = identity(i,j,k,l)*A(k,l);
 
@@ -63,10 +63,10 @@ TEST(Identity, Matrix) {
     for (int n = 0; n < 3; ++n) {
       for (int o = 0; o < 3; ++o) {
         for (int p = 0; p < 3; ++p) {
-          EXPECT_EQ(I(m,n,o,p), J(m,n,o,p));
+          EXPECT_EQ(ID(m,n,o,p), J(m,n,o,p));
         }
       }
-      EXPECT_EQ(I(m,n,m,n), 1);
+      EXPECT_EQ(ID(m,n,m,n), 1);
       EXPECT_EQ(B(m,n), A(m,n));
       EXPECT_EQ(C(m,n), A(m,n));
       EXPECT_EQ(D(m,n), A(m,n));

--- a/test/Inverse.cpp
+++ b/test/Inverse.cpp
@@ -44,22 +44,22 @@ TEST(Inverse, Basic_2_2) {
   ttl::Tensor<2,2,double> A = {1, 2, 3, 5},
                           B = ttl::inverse(A),
                           C = B(i,j)*A(j,k),
-                          I = identity(i,j);
+                          ID = identity(i,j);
 
-  EXPECT_DOUBLE_EQ(C(0,0), I(0,0));
-  EXPECT_DOUBLE_EQ(C(0,1), I(0,1));
-  EXPECT_DOUBLE_EQ(C(1,0), I(1,0));
-  EXPECT_DOUBLE_EQ(C(1,1), I(1,1));
+  EXPECT_DOUBLE_EQ(C(0,0), ID(0,0));
+  EXPECT_DOUBLE_EQ(C(0,1), ID(0,1));
+  EXPECT_DOUBLE_EQ(C(1,0), ID(1,0));
+  EXPECT_DOUBLE_EQ(C(1,1), ID(1,1));
 
   B = zero(i,j);
   int e = ttl::inverse(A,B);
   C = B(i,j)*A(j,k);
 
   EXPECT_EQ(e, 0);
-  EXPECT_DOUBLE_EQ(C(0,0), I(0,0));
-  EXPECT_DOUBLE_EQ(C(0,1), I(0,1));
-  EXPECT_DOUBLE_EQ(C(1,0), I(1,0));
-  EXPECT_DOUBLE_EQ(C(1,1), I(1,1));
+  EXPECT_DOUBLE_EQ(C(0,0), ID(0,0));
+  EXPECT_DOUBLE_EQ(C(0,1), ID(0,1));
+  EXPECT_DOUBLE_EQ(C(1,0), ID(1,0));
+  EXPECT_DOUBLE_EQ(C(1,1), ID(1,1));
 }
 
 TEST(Inverse, Singular_2_2) {
@@ -83,17 +83,17 @@ TEST(Inverse, Basic_2_3) {
                                       7, 8, 10},
                                  B = inverse(A),
                                  C = B(i,j)*A(j,k),
-                                 I = identity(i,j);
+                                 ID = identity(i,j);
 
-  EXPECT_NEAR(C(0,0), I(0,0), 1e-14);
-  EXPECT_NEAR(C(0,1), I(0,1), 1e-14);
-  EXPECT_NEAR(C(0,2), I(0,2), 1e-14);
-  EXPECT_NEAR(C(1,0), I(1,0), 1e-14);
-  EXPECT_NEAR(C(1,1), I(1,1), 1e-14);
-  EXPECT_NEAR(C(1,2), I(1,2), 1e-14);
-  EXPECT_NEAR(C(2,0), I(2,0), 1e-14);
-  EXPECT_NEAR(C(2,1), I(2,1), 1e-14);
-  EXPECT_NEAR(C(2,2), I(2,2), 1e-14);
+  EXPECT_NEAR(C(0,0), ID(0,0), 1e-14);
+  EXPECT_NEAR(C(0,1), ID(0,1), 1e-14);
+  EXPECT_NEAR(C(0,2), ID(0,2), 1e-14);
+  EXPECT_NEAR(C(1,0), ID(1,0), 1e-14);
+  EXPECT_NEAR(C(1,1), ID(1,1), 1e-14);
+  EXPECT_NEAR(C(1,2), ID(1,2), 1e-14);
+  EXPECT_NEAR(C(2,0), ID(2,0), 1e-14);
+  EXPECT_NEAR(C(2,1), ID(2,1), 1e-14);
+  EXPECT_NEAR(C(2,2), ID(2,2), 1e-14);
 
   Tensor<2,3,double> D;
   int singular = inverse(A(i,j), D);
@@ -101,15 +101,15 @@ TEST(Inverse, Basic_2_3) {
 
   Tensor<2,3,double> E = D(i,j)*A(j,k);
 
-  EXPECT_NEAR(E(0,0), I(0,0), 1e-14);
-  EXPECT_NEAR(E(0,1), I(0,1), 1e-14);
-  EXPECT_NEAR(E(0,2), I(0,2), 1e-14);
-  EXPECT_NEAR(E(1,0), I(1,0), 1e-14);
-  EXPECT_NEAR(E(1,1), I(1,1), 1e-14);
-  EXPECT_NEAR(E(1,2), I(1,2), 1e-14);
-  EXPECT_NEAR(E(2,0), I(2,0), 1e-14);
-  EXPECT_NEAR(E(2,1), I(2,1), 1e-14);
-  EXPECT_NEAR(E(2,2), I(2,2), 1e-14);
+  EXPECT_NEAR(E(0,0), ID(0,0), 1e-14);
+  EXPECT_NEAR(E(0,1), ID(0,1), 1e-14);
+  EXPECT_NEAR(E(0,2), ID(0,2), 1e-14);
+  EXPECT_NEAR(E(1,0), ID(1,0), 1e-14);
+  EXPECT_NEAR(E(1,1), ID(1,1), 1e-14);
+  EXPECT_NEAR(E(1,2), ID(1,2), 1e-14);
+  EXPECT_NEAR(E(2,0), ID(2,0), 1e-14);
+  EXPECT_NEAR(E(2,1), ID(2,1), 1e-14);
+  EXPECT_NEAR(E(2,2), ID(2,2), 1e-14);
 }
 
 TEST(Inverse, Singular_2_3) {
@@ -218,14 +218,14 @@ TEST(Inverse, Basic_4_2) {
                                11,13,12,14,
                                -16,17,-18,19},
                           B = ttl::inverse(A),
-                          C = B(i,j,k,l)*A(k,l,m,n), I;
-  I(i,j,k,l) = ttl::identity(i,j,k,l);
+                          C = B(i,j,k,l)*A(k,l,m,n), ID;
+  ID(i,j,k,l) = ttl::identity(i,j,k,l);
 
   for (int q = 0; q < 2; ++q) {
     for (int r = 0; r < 2; ++r) {
       for (int s = 0; s < 2; ++s) {
         for (int t = 0; t < 2; ++t) {
-          EXPECT_NEAR(C(q,r,s,t), I(q,r,s,t), 1e-13);
+          EXPECT_NEAR(C(q,r,s,t), ID(q,r,s,t), 1e-13);
         }
       }
     }
@@ -240,7 +240,7 @@ TEST(Inverse, Basic_4_2) {
     for (int r = 0; r < 2; ++r) {
       for (int s = 0; s < 2; ++s) {
         for (int t = 0; t < 2; ++t) {
-          EXPECT_NEAR(C(q,r,s,t), I(q,r,s,t), 1e-13);
+          EXPECT_NEAR(C(q,r,s,t), ID(q,r,s,t), 1e-13);
         }
       }
     }
@@ -271,8 +271,8 @@ TEST(Inverse, Basic_4_3) {
   ttl::Index<'m'> m;
   ttl::Index<'n'> n;
 
-  ttl::Tensor<4,3,double> A, I;
-  I(i,j,k,l) = ttl::identity(i,j,k,l);
+  ttl::Tensor<4,3,double> A, ID;
+  ID(i,j,k,l) = ttl::identity(i,j,k,l);
   for (int q = 0; q < 3; ++q) {
     for (int r = 0; r < 3; ++r) {
       for (int s = 0; s < 3; ++s) {
@@ -291,7 +291,7 @@ TEST(Inverse, Basic_4_3) {
     for (int r = 0; r < 2; ++r) {
       for (int s = 0; s < 2; ++s) {
         for (int t = 0; t < 2; ++t) {
-          EXPECT_NEAR(C(q,r,s,t), I(q,r,s,t), 1e-13);
+          EXPECT_NEAR(C(q,r,s,t), ID(q,r,s,t), 1e-13);
         }
       }
     }


### PR DESCRIPTION
Some BLAS/LAPACK implementations ([OpenBLAS](https://github.com/xianyi/OpenBLAS)) may include the C `complex.h` header, which defines the `I` macro ([source](http://en.cppreference.com/w/c/numeric/complex/I)). This will conflict with the used `I` symbol of the TTL test cases and throw a compiler error.

This pull request simply renames the symbol `I` to `ID`, thereby avoiding any macro conflicts.